### PR TITLE
 Add user_info support

### DIFF
--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -90,6 +90,19 @@ defmodule Ueberauth.Strategy.OIDC do
         conn
         |> put_private(:ueberauth_oidc_opts, opts)
         |> put_private(:ueberauth_oidc_tokens, tokens)
+        |> maybe_put_userinfo(opts)
+    end
+  end
+
+  defp maybe_put_userinfo(%{private: %{ueberauth_oidc_tokens: tokens}} = conn, opts) do
+    with true <- opts |> option(:user_info) |> is_bitstring(),
+         provider <- get_provider(opts),
+         token <- scrub_value(tokens[:access][:token]),
+         {:ok, user_info} <- :oidcc.retrieve_user_info(token, provider) do
+      user_info = for {k, v} <- user_info, do: {to_string(k), v}, into: %{}
+      put_private(conn, :ueberauth_oidc_user_info, user_info)
+    else
+      _ -> conn
     end
   end
 
@@ -98,6 +111,7 @@ defmodule Ueberauth.Strategy.OIDC do
     conn
     |> put_private(:ueberauth_oidc_opts, nil)
     |> put_private(:ueberauth_oidc_tokens, nil)
+    |> put_private(:ueberauth_oidc_user_info, nil)
   end
 
   @doc """
@@ -105,8 +119,15 @@ defmodule Ueberauth.Strategy.OIDC do
   """
   def uid(conn) do
     private = conn.private
-    uid_field = option(private.ueberauth_oidc_opts, :uid_field)
-    scrub_value(private.ueberauth_oidc_tokens[:id][:claims][uid_field])
+
+    with user_info <- option(private.ueberauth_oidc_opts, :user_info),
+         true <- is_bitstring(user_info) do
+      scrub_value(private.ueberauth_oidc_user_info[user_info])
+    else
+      _ ->
+        uid_field = option(private.ueberauth_oidc_opts, :uid_field)
+        scrub_value(private.ueberauth_oidc_tokens[:id][:claims][uid_field])
+    end
   end
 
   @doc """
@@ -117,6 +138,7 @@ defmodule Ueberauth.Strategy.OIDC do
   def credentials(conn) do
     private = conn.private
     tokens = conn.private.ueberauth_oidc_tokens
+    user_info = conn.private[:ueberauth_oidc_user_info]
 
     exp_at =
       tokens[:access][:expires]
@@ -131,6 +153,7 @@ defmodule Ueberauth.Strategy.OIDC do
       expires_at: exp_at,
       scopes: scrub_value(tokens[:scope][:list]),
       other: %{
+        user_info: user_info,
         provider: get_provider(private.ueberauth_oidc_opts),
         id_token: scrub_value(tokens[:id][:token])
       }

--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -95,7 +95,7 @@ defmodule Ueberauth.Strategy.OIDC do
   end
 
   defp maybe_put_userinfo(%{private: %{ueberauth_oidc_tokens: tokens}} = conn, opts) do
-    with true <- opts |> option(:user_info) |> is_bitstring(),
+    with true <- option(opts, :fetch_userinfo),
          provider <- get_provider(opts),
          token <- scrub_value(tokens[:access][:token]),
          {:ok, user_info} <- :oidcc.retrieve_user_info(token, provider) do
@@ -120,7 +120,8 @@ defmodule Ueberauth.Strategy.OIDC do
   def uid(conn) do
     private = conn.private
 
-    with user_info <- option(private.ueberauth_oidc_opts, :user_info),
+    with true <- option(private.ueberauth_oidc_opts, :fetch_userinfo),
+         user_info <- option(private.ueberauth_oidc_opts, :userinfo_uid_field),
          true <- is_bitstring(user_info) do
       scrub_value(private.ueberauth_oidc_user_info[user_info])
     else

--- a/test/ueberauth_oidc/strategy/oidc_test.exs
+++ b/test/ueberauth_oidc/strategy/oidc_test.exs
@@ -45,11 +45,17 @@ defmodule Ueberauth.Strategy.OIDCTest do
       end
     end
 
-    test "Handle callback from provider with a session_id, validate tokens" do
-      with_mock :oidcc,
-        retrieve_and_validate_token: fn _, _, _ ->
-          {:ok, %{id: %{claims: :claims}, access: %{hash: :verified}}}
-        end do
+    test "Handle callback from provider with a uid_field in the id_token" do
+      with_mocks [
+        {:oidcc, [],
+         [
+           retrieve_and_validate_token: fn _, _, _ ->
+             {:ok, %{id: %{claims: :claims}, access: %{hash: :verified, token: "123"}}}
+           end
+         ]},
+        {Ueberauth.Strategy.Helpers, [:passtrough],
+         [options: fn _ -> [test_provider: [user_info: nil]] end]}
+      ] do
         callback =
           OIDC.handle_callback!(%Plug.Conn{
             params: %{"state" => 1234, "code" => 1234, "oidc_provider" => "test_provider"},
@@ -58,8 +64,40 @@ defmodule Ueberauth.Strategy.OIDCTest do
 
         assert %Plug.Conn{
                  private: %{
-                   ueberauth_oidc_opts: [provider: "test_provider", uid_field: _],
+                   ueberauth_oidc_opts: [provider: "test_provider", uid_field: _, user_info: nil],
                    ueberauth_oidc_tokens: %{access: _, id: _}
+                 }
+               } = callback
+      end
+    end
+
+    test "Handle callback from provider with a user_info endpoint" do
+      with_mocks [
+        {:oidcc, [],
+         [
+           retrieve_user_info: fn _, _ -> {:ok, %{:uid => "atom_key", "sub" => "string_key"}} end,
+           retrieve_and_validate_token: fn _, _, _ ->
+             {:ok, %{id: %{claims: :claims}, access: %{hash: :verified, token: "123"}}}
+           end
+         ]},
+        {Ueberauth.Strategy.Helpers, [:passtrough],
+         [options: fn _ -> [test_provider: [user_info: "uid"]] end]}
+      ] do
+        callback =
+          OIDC.handle_callback!(%Plug.Conn{
+            params: %{"state" => 1234, "code" => 1234, "oidc_provider" => "test_provider"},
+            private: %{ueberauth_request_options: %{options: []}}
+          })
+
+        assert %Plug.Conn{
+                 private: %{
+                   ueberauth_oidc_opts: [
+                     provider: "test_provider",
+                     uid_field: _,
+                     user_info: "uid"
+                   ],
+                   ueberauth_oidc_tokens: %{access: _, id: _},
+                   ueberauth_oidc_user_info: %{"sub" => "string_key", "uid" => "atom_key"}
                  }
                } = callback
       end
@@ -164,7 +202,18 @@ defmodule Ueberauth.Strategy.OIDCTest do
                OIDC.handle_cleanup!(conn_with_values)
     end
 
-    test "Get the uid from the conn" do
+    test "Get the uid from the user_info" do
+      conn = %Plug.Conn{
+        private: %{
+          ueberauth_oidc_opts: [user_info: "upn"],
+          ueberauth_oidc_user_info: %{"upn" => "upn_id"}
+        }
+      }
+
+      assert OIDC.uid(conn) == "upn_id"
+    end
+
+    test "Get the uid from the id_token" do
       conn = %Plug.Conn{
         private: %{
           ueberauth_oidc_opts: [uid_field: :sub],


### PR DESCRIPTION
Also opened a PR on the source: https://github.com/rng2/ueberauth_oidc/pull/2

If user_info field is set in the provider config, it retrieves the user_info endpoint and uses the config value for the uid_field, instead of using the one in the id_token