### PR TITLE
Improve error handling when fetching token response fails

### DIFF
--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -49,11 +49,14 @@ defmodule Ueberauth.Strategy.OIDC do
           |> put_private(:ueberauth_oidc_opts, opts)
           |> maybe_put_userinfo(opts, access_token)
         else
+          {:error, type, reason} ->
+            set_error!(conn, type, reason)
+
           {:error, reason} ->
             set_error!(conn, "error", reason)
 
-          _ ->
-            set_error!(conn, "error", "Unexpected token response")
+          error ->
+            set_error!(conn, "unknown_error", error)
         end
     end
   end


### PR DESCRIPTION
Improves handling of errors when fetching / validating token responses. Adds handling of errors in the format `{:error, :reason, <message>}` (previously only `{:error, <message>}` was handled.

Also adds a catch-all fallback in the (rare) case a server would return an unexpected non-standard response.