### PR TITLE
Use the 'Ueberauth.Strategy.OIDC' key for config, update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,12 @@ Has optional support for `/userinfo` endpoints, and has the option to get a user
       providers: [
         oidc: { Ueberauth.Strategy.OIDC, [
           default: [
-            # required
-            provider: :default_provider,
+            # required, set to default provider you want to use
+            provider: :default_oidc,
 
             # optional
             uid_field: :sub
           ],
-
-          default_provider: [
-            fetch_userinfo: true, # true/false
-            userinfo_uid_field: "upn", # only include if getting the user_id from userinfo
-            uid_field: "sub" # only include if getting the user_id from the claims
-          ]
 
           # optional override for each provider
           google: [uid_field: :email],
@@ -60,9 +54,12 @@ See [OpenIDConnect](https://hexdocs.pm/openid_connect/readme.html)
 for a list of supported options.
 
     ```elixir
-    config :ueberauth, UeberauthOIDC,
+    config :ueberauth, Ueberauth.Strategy.OIDC,
       # one or more providers
       default_oidc: [
+        fetch_userinfo: true, # true/false
+        userinfo_uid_field: "upn", # only include if getting the user_id from userinfo
+        uid_field: "sub" # only include if getting the user_id from the claims
         discovery_document_uri: "https://oidc.example/.well-known/openid-configuration",
         client_id: "client_id",
         client_secret: "123456789",
@@ -116,7 +113,7 @@ will be empty. Use the information in `Ueberauth.Auth.Credentials` and
       ...
       children = [
         ...,
-        {OpenIDConnect.Worker, Application.get_env(:ueberauth, UeberauthOIDC)},
+        {OpenIDConnect.Worker, Application.get_env(:ueberauth, Ueberauth.Strategy.OIDC)},
         ...
       ]
       ...

--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -176,8 +176,8 @@ defmodule Ueberauth.Strategy.OIDC do
   defp option(opts, key), do: Keyword.get(opts, key)
 
   defp get_options!(conn) do
-    all_opts = options(conn)
-    supplied_defaults = Keyword.get(all_opts, :default, [])
+    oidc_opts = Application.get_env(:ueberauth, __MODULE__, [])
+    supplied_defaults = conn |> options() |> Keyword.get(:default, [])
 
     # untrusted input
     provider_id = conn.params["oidc_provider"] || Keyword.fetch!(supplied_defaults, :provider)
@@ -185,10 +185,10 @@ defmodule Ueberauth.Strategy.OIDC do
     provider_opts =
       case is_atom(provider_id) do
         true ->
-          Keyword.get(all_opts, provider_id, [])
+          Keyword.get(oidc_opts, provider_id, [])
 
         false ->
-          Enum.find_value(all_opts, [], fn {key, val} ->
+          Enum.find_value(oidc_opts, [], fn {key, val} ->
             if provider_id == to_string(key), do: val
           end)
       end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule UeberauthOIDC.Mixfile do
   use Mix.Project
 
-  @version "0.0.2"
+  @version "0.0.3"
 
   def project do
     [

--- a/test/ueberauth_oidc/strategy/oidc_test.exs
+++ b/test/ueberauth_oidc/strategy/oidc_test.exs
@@ -54,8 +54,10 @@ defmodule Ueberauth.Strategy.OIDCTest do
     end
 
     test "Handle callback from provider with a uid_field in the id_token" do
-      with_mock Ueberauth.Strategy.Helpers, [:passtrough],
-        options: fn _ -> [test_provider: [fetch_userinfo: false, uid_field: "uid"]] end do
+      with_mock Application, [:passtrough],
+        get_env: fn :ueberauth, OIDC, [] ->
+          [test_provider: [fetch_userinfo: false, uid_field: "uid"]]
+        end do
         callback =
           OIDC.handle_callback!(%Plug.Conn{
             params: %{"code" => 1234, "oidc_provider" => "test_provider"},
@@ -85,8 +87,12 @@ defmodule Ueberauth.Strategy.OIDCTest do
              %HTTPoison.Response{body: "{\"sub\":\"string_key\",\"uid\":\"atom_key\"}"}
            end
          ]},
-        {Ueberauth.Strategy.Helpers, [:passtrough],
-         [options: fn _ -> [test_provider: [fetch_userinfo: true, userinfo_uid_field: "uid"]] end]}
+        {Application, [:passtrough],
+         [
+           get_env: fn :ueberauth, OIDC, [] ->
+             [test_provider: [fetch_userinfo: true, userinfo_uid_field: "uid"]]
+           end
+         ]}
       ] do
         callback =
           OIDC.handle_callback!(%Plug.Conn{


### PR DESCRIPTION
To make it more in-line with other Ueberauth librarys and to make it easier to set dynamic values (for example when set through the `runtime.exs` config), get the OIDC config values directly from the `Ueberauth.Strategy.OIDC` application env.