### PR TITLE
Make the HTTP client configurable

### DIFF
--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -77,7 +77,7 @@ defmodule Ueberauth.Strategy.OIDC do
 
     with %{"userinfo_endpoint" => userinfo_endpoint} <-
            GenServer.call(:openid_connect, {:discovery_document, provider_id}),
-         %HTTPoison.Response{body: body} <- HTTPoison.get!(userinfo_endpoint, headers),
+         %HTTPoison.Response{body: body} <- http_client().get!(userinfo_endpoint, headers),
          userinfo_claims <- Jason.decode!(body) do
       user_info = for {k, v} <- userinfo_claims, do: {to_string(k), v}, into: %{}
       {:ok, user_info}
@@ -213,5 +213,9 @@ defmodule Ueberauth.Strategy.OIDC do
   defp unix_now() do
     {mega, sec, _micro} = :os.timestamp()
     mega * 1_000_000 + sec
+  end
+
+  defp http_client() do
+    Application.get_env(:ueberauth_oidc, :http_client, HTTPoison)
   end
 end

--- a/test/ueberauth_oidc/strategy/oidc_test.exs
+++ b/test/ueberauth_oidc/strategy/oidc_test.exs
@@ -89,8 +89,10 @@ defmodule Ueberauth.Strategy.OIDCTest do
          ]},
         {Application, [:passtrough],
          [
-           get_env: fn :ueberauth, OIDC, [] ->
-             [test_provider: [fetch_userinfo: true, userinfo_uid_field: "uid"]]
+           get_env: fn
+             (:ueberauth, OIDC, []) ->
+               [test_provider: [fetch_userinfo: true, userinfo_uid_field: "uid"]]
+             (:ueberauth_oidc, _, default) -> default
            end
          ]}
       ] do


### PR DESCRIPTION
This is mostly useful for allowing for custom modules to be defined using the `HTTPoison.Base` behavior, e.g. for overriding SSL settings.