### PR TITLE
Use fetched user info to populate `Info` struct

### DIFF
--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -155,13 +155,20 @@ defmodule Ueberauth.Strategy.OIDC do
   end
 
   @doc """
-  Returns an empty `Ueberauth.Auth.Info` struct.
+  Returns a `Ueberauth.Auth.Info` struct populated with the data returned from
+  the userinfo endpoint.
 
-  Use information included in the `Ueberauth.Auth.Credentials` and
-  `Ueberauth.Auth.Extra` structs instead.
+  This information is also included in the `Ueberauth.Auth.Credentials` struct.
   """
-  def info(_conn) do
-    %Info{}
+  def info(conn) do
+    with user_info when not is_nil(user_info) <-
+           conn.private[:ueberauth_oidc_user_info],
+         user_info <-
+           Enum.map(user_info, fn {k, v} -> {String.to_existing_atom(k), v} end) do
+      struct(Info, user_info)
+    else
+      _ -> %Info{}
+    end
   end
 
   defp scrub_value(:undefined), do: nil

--- a/test/ueberauth_oidc/strategy/oidc_test.exs
+++ b/test/ueberauth_oidc/strategy/oidc_test.exs
@@ -286,6 +286,35 @@ defmodule Ueberauth.Strategy.OIDCTest do
              } = OIDC.credentials(conn)
     end
 
+    test "Get info from the conn" do
+      conn = %Plug.Conn{
+        private: %{
+          ueberauth_oidc_user_info: %{
+            "name" => "name",
+            "email" => "email",
+          }
+        }
+      }
+
+      assert %Ueberauth.Auth.Info{
+               name: "name",
+               email: "email"
+             } = OIDC.info(conn)
+    end
+
+    test "Get info from the conn when fetch_userinfo is disabled" do
+      conn = %Plug.Conn{
+        private: %{
+          ueberauth_oidc_user_info: nil
+        }
+      }
+
+      assert %Ueberauth.Auth.Info{
+               name: nil,
+               email: nil
+             } = OIDC.info(conn)
+    end
+
     test "Puts the raw token map in the Extra struct" do
       conn = %Plug.Conn{
         private: %{


### PR DESCRIPTION
Use the user info data that was fetched to build the `Ueberauth.Auth.Info` struct instead of instructing developers to look for the data elsewhere.