### PR TITLE
Fix mapping userinfo to Ueberauth.Auth.Info struct

### DIFF
--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -168,11 +168,13 @@ defmodule Ueberauth.Strategy.OIDC do
   This information is also included in the `Ueberauth.Auth.Credentials` struct.
   """
   def info(conn) do
-    with user_info when not is_nil(user_info) <-
-           conn.private[:ueberauth_oidc_user_info],
-         user_info <-
-           Enum.map(user_info, fn {k, v} -> {String.to_existing_atom(k), v} end) do
-      struct(Info, user_info)
+    with user_info when not is_nil(user_info) <- conn.private[:ueberauth_oidc_user_info] do
+      %Info{}
+      |> Map.from_struct()
+      |> Enum.reduce(%Info{}, fn {k, v}, struct ->
+        string_key = Atom.to_string(k)
+        Map.put(struct, k, Map.get(user_info, string_key, v))
+      end)
     else
       _ -> %Info{}
     end

--- a/test/ueberauth_oidc/strategy/oidc_test.exs
+++ b/test/ueberauth_oidc/strategy/oidc_test.exs
@@ -319,6 +319,27 @@ defmodule Ueberauth.Strategy.OIDCTest do
              } = OIDC.info(conn)
     end
 
+    test "Get info from the conn and ignore invalid fields" do
+      info =
+        OIDC.info(%Plug.Conn{
+          private: %{
+            ueberauth_oidc_user_info: %{
+              "name" => "name",
+              "foo" => "bar"
+            }
+          }
+        })
+
+      refute Map.has_key?(info, :foo)
+      assert %Ueberauth.Auth.Info{name: "name"} = info
+    end
+
+    test "Get info from the conn when there is no info field" do
+      info = OIDC.info(%Plug.Conn{private: %{}})
+
+      assert %Ueberauth.Auth.Info{name: nil, email: nil} = info
+    end
+
     test "Get info from the conn when fetch_userinfo is disabled" do
       conn = %Plug.Conn{
         private: %{


### PR DESCRIPTION
The mapping of `userinfo` to the `Ueberauth.Auth.Info` struct got introduced in @tylerhunt's PR #8

When trying to map the `userinfo` to an `Ueberauth.Auth.Info` struct, it tries to map the values using `String.to_existing_atom`.

This works when the userinfo has the expected fields, but when an OIDC provider provides unexpected fields here, it will fail because those atoms do not exist.

We encountered this in one of our implementations, but didn't catch these in the tests or review environments.
I also updated the tests for the Info struct to include more scenario's.

This is fixed by always mapping explicitly to the fields present in the `%Info{}` struct.

@tylerhunt what do you think of this solution?