### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule UeberauthOIDC.Mixfile do
     [
       app: :ueberauth_oidc,
       name: "Ueberauth OIDC",
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.7",
       description: """
       An Ueberauth strategy for generic OpenID Connect authentication.


### PR DESCRIPTION
Bump version to 0.1.3.

Adds a fix for the CRSF checks added in Ueberauth 0.7