### PR TITLE
fix: Accept the "exp" claim as the time at which the token expires

### DIFF
--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -237,12 +237,7 @@ defmodule Ueberauth.Strategy.OIDC do
     |> expires_at()
   end
 
-  defp expires_at(expires_in), do: unix_now() + expires_in
-
-  defp unix_now do
-    {mega, sec, _micro} = :os.timestamp()
-    mega * 1_000_000 + sec
-  end
+  defp expires_at(expires_at), do: expires_at
 
   defp http_client do
     Application.get_env(:ueberauth_oidc, :http_client, HTTPoison)

--- a/test/ueberauth_oidc/strategy/oidc_test.exs
+++ b/test/ueberauth_oidc/strategy/oidc_test.exs
@@ -313,6 +313,31 @@ defmodule Ueberauth.Strategy.OIDCTest do
 
       assert %{
                expires: true,
+               expires_at: 1234,
+               other: %{user_info: nil, provider: "some_provider"},
+               token: "1234",
+               token_type: "Bearer"
+             } = OIDC.credentials(conn)
+    end
+
+    test "Parses a binary exp value" do
+      conn = %Plug.Conn{
+        private: %{
+          ueberauth_oidc_tokens: %{
+            "id_token" => "4321",
+            "access_token" => "1234",
+            "token_type" => "Bearer"
+          },
+          ueberauth_oidc_claims: %{
+            "exp" => "1234"
+          },
+          ueberauth_oidc_opts: [provider: "some_provider"]
+        }
+      }
+
+      assert %{
+               expires: true,
+               expires_at: 1234,
                other: %{user_info: nil, provider: "some_provider"},
                token: "1234",
                token_type: "Bearer"


### PR DESCRIPTION
According to the spec, the "exp" claim is the "Expiration time on or
after which the ID Token MUST NOT be accepted for processing." Do not
add it to the current time.

Addresses https://github.com/DefactoSoftware/ueberauth_oidc/issues/17