### PR TITLE
Allow Dynamic Scope Override

### DIFF
--- a/lib/ueberauth/strategy/oidc.ex
+++ b/lib/ueberauth/strategy/oidc.ex
@@ -68,6 +68,7 @@ defmodule Ueberauth.Strategy.OIDC do
 
     %{redirect_uri: redirect_uri || callback_url(conn)}
     |> Map.merge(state_params(conn))
+    |> Map.merge(scope_params(conn))
     |> Map.merge(params)
   end
 
@@ -75,6 +76,13 @@ defmodule Ueberauth.Strategy.OIDC do
     case conn.private[:ueberauth_state_param] do
       nil -> %{}
       state -> %{state: state}
+    end
+  end
+
+  defp scope_params(conn) do
+    case conn.private[:ueberauth_request_scope] do
+      nil -> %{}
+      scope -> %{scope: scope}
     end
   end
 


### PR DESCRIPTION
We have a use case, where depending on some values set in the session we want to ask for different `scopes`.

The idea is to use this like this:

```elixir
defmodule AcmeWeb.AuthController do
  use AcmeWeb, :controller

  plug :set_scopes
  
  plug Ueberauth 
  
  def set_scopes(%Plug.Con{} = conn, _opts) do
    scopes = "openid profile anything" # For example extracted from the session
    put_private(conn, :ueberauth_request_scope, scopes)
  end
  
  # ...
```